### PR TITLE
Fix special fly movement redirection, update images, and adjust fly rewards

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -28,3 +28,4 @@ BACKGROUND_COLOR = (243, 207, 198)  # Background color of the screen
 BLACK_COLOR = (0, 0, 0)  # Color for score and time text
 GOLD_COLOR = (255, 223, 0)  # Color for special popups
 GRAY_COLOR = (169, 169, 169)  # Color for regular popups
+

--- a/src/constants.py
+++ b/src/constants.py
@@ -26,6 +26,6 @@ INITIAL_SCREEN_HEIGHT = 600
 # Color constants
 BACKGROUND_COLOR = (243, 207, 198)  # Background color of the screen
 BLACK_COLOR = (0, 0, 0)  # Color for score and time text
-GOLD_COLOR = (255, 223, 0)  # Color for special popups
+GOLD_COLOR = (204, 183, 50) # Color for special popups
 GRAY_COLOR = (169, 169, 169)  # Color for regular popups
 

--- a/src/game_logic.py
+++ b/src/game_logic.py
@@ -33,8 +33,11 @@ def update_frog_and_flies(game_state, screen_width, screen_height):
     for fly in game_state.flies[:]:
         if check_collision(game_state.frog, fly):
             game_state.flies.remove(fly)
-            game_state.score += 1
-            game_state.countdown_time += 25 if isinstance(fly, SpecialFly) else 5
+            
+            if isinstance(fly, SpecialFly):   
+                game_state.countdown_time += 5
+            else:
+                game_state.score += 1
 
             # Store the position and timestamp of the score popup
             game_state.score_popups.append({

--- a/src/special_fly.py
+++ b/src/special_fly.py
@@ -1,3 +1,4 @@
+import pygame
 import random
 from constants import SPECIAL_FLY_LEFT, SPECIAL_FLY_RIGHT
 from fly import Fly
@@ -44,11 +45,13 @@ class SpecialFly(Fly):
         if fly_center_x < screen_center_x and self.movement["left"]:
             self.movement["left"] = False
             self.movement["right"] = True
+            self.img = pygame.transform.scale(self.img_right, (int(self.width), int(self.height)))
 
         # If the fly is in the right half and moving right, change direction to left
         if fly_center_x > screen_center_x and self.movement["right"]:
             self.movement["right"] = False
             self.movement["left"] = True
+            self.img = pygame.transform.scale(self.img_left, (int(self.width), int(self.height)))
 
         # If the fly is in the top half and moving up, change direction to down
         if fly_center_y < screen_center_y and self.movement["up"]:

--- a/src/special_fly.py
+++ b/src/special_fly.py
@@ -26,32 +26,40 @@ class SpecialFly(Fly):
 
     def adjust_movement(self, screen_width, screen_height):
         """
-        Adjusts the movement direction of the fly if it's too close to the screen edge.
+        Redirects the fly's movement if it's too close to one half of the screen  
+        and moving further in that direction. This helps ensure flies stay within  
+        a balanced play area, giving the player enough time to react and catch them.
 
         Args:
-            screen_width (int): The width of the screen, used to check if the fly is too close to the right or left edge.
-            screen_height (int): The height of the screen, used to check if the fly is too close to the top or bottom edge.
+            screen_width (int): The width of the screen, used to determine positioning.
+            screen_height (int): The height of the screen, used to determine positioning.
         """
-        # If the fly is near the left edge and moving left, change direction to right
-        if self.x <= 0 and self.movement["left"]:
+        fly_center_x = self.x + self.width / 2
+        fly_center_y = self.y + self.height / 2
+
+        screen_center_x = screen_width / 2
+        screen_center_y = screen_height / 2
+
+        # If the fly is in the left half and moving left, change direction to right
+        if fly_center_x < screen_center_x and self.movement["left"]:
             self.movement["left"] = False
             self.movement["right"] = True
 
-        # If the fly is near the right edge and moving right, change direction to left
-        if self.x + self.width >= screen_width and self.movement["right"]:
+        # If the fly is in the right half and moving right, change direction to left
+        if fly_center_x > screen_center_x and self.movement["right"]:
             self.movement["right"] = False
             self.movement["left"] = True
 
-        # If the fly is near the top edge and moving up, change direction to down
-        if self.y <= 0 and self.movement["up"]:
+        # If the fly is in the top half and moving up, change direction to down
+        if fly_center_y < screen_center_y and self.movement["up"]:
             self.movement["up"] = False
             self.movement["down"] = True
 
-        # If the fly is near the bottom edge and moving down, change direction to up
-        if self.y + self.height >= screen_height and self.movement["down"]:
+        # If the fly is in the bottom half and moving down, change direction to up
+        if fly_center_y > screen_center_y and self.movement["down"]:
             self.movement["down"] = False
             self.movement["up"] = True
-    
+
     def move(self, screen_width, screen_height):
         """
         Moves the special fly and returns a boolean indicating whether the fly is still on the screen.

--- a/src/ui_renderer.py
+++ b/src/ui_renderer.py
@@ -31,7 +31,7 @@ def draw_popups(score_popups, screen):
     for popup in score_popups:
         if current_time - popup["time"] < 1000:  # Show for 1 second
             color = GOLD_COLOR if popup["special"] else GRAY_COLOR
-            text = font.render("+25s" if popup["special"] else "+5s", True, color)
+            text = font.render("+5s" if popup["special"] else "+1", True, color)
             screen.blit(text, (popup["pos"][0], popup["pos"][1] - 20))
             active_popups.append(popup)  # Keep active popups
 


### PR DESCRIPTION
This PR includes improvements to special fly movement redirection, image updates, and reward adjustments:
- Fix fly redirection: The fly now changes direction based on the screen center instead of the edges to give the player more time to catch it.
- Update fly images: The fly’s image now updates correctly when switching between left and right movement.
- Adjust rewards for flies:
         - Regular flies now increase the score by 1 and display a "+1" popup.
         - Special flies no longer increase the score but instead add 5 seconds to the countdown timer, with a "+5s" popup.
         - Previously, both fly types increased the score, regular flies added 5s, and special flies added 25s to the timer.